### PR TITLE
codeblocks/find-emacs-dirs: Initial commit

### DIFF
--- a/.github/workflows/runtime-test.yml
+++ b/.github/workflows/runtime-test.yml
@@ -1,0 +1,65 @@
+# Continuous Integration that checks if the change broke the runtime of the used emacs-lisp scripts
+name: runtime-test
+
+# Relevant to events - https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/RXT0128/codeblocks/find-emacs-dirs.el'
+      - 'src/RXT0128/00-init-prepend.el'
+      - 'src/RXT0128/01-init-append.el'
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - 'src/RXT0128/codeblocks/find-emacs-dirs.el'
+      - 'src/RXT0128/00-init-prepend.el'
+      - 'src/RXT0128/01-init-append.el'
+  releases:
+    types:
+      - created
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container: debian:stable
+    steps:
+      - name: Installing dependencies..
+        shell: bash
+        run: |
+          apt-get update -q
+          apt-get install emacs -qy
+     - name: Pulling the repository..
+       uses: actions/checkout@v2
+     - name: Performing the test..
+       shell: bash
+       run: |
+         cd "$GITHUB_WORKSPACE"
+         make runtime-emacs-script
+  darwin:
+    runs-on: macos-latest
+    steps:
+      - name: Installing dependencies..
+        shell: bash
+        run: |
+          # Based on http://wikemacs.org/wiki/Installing_Emacs_on_OS_X#Homebrew_recommended_by_brew
+          brew update
+          brew cask install emacs
+     - name: Pulling the repository..
+       uses: actions/checkout@v2
+     - name: Performing the test..
+       shell: bash
+       run: |
+         cd "$GITHUB_WORKSPACE"
+         make runtime-emacs-script
+  windows:
+    runs-on: windows-latest 
+    steps:
+      - name: Pulling the repository..
+        uses: actions/checkout@v2
+      - name: Performing the test..
+        shell: bash
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          make runtime-emacs-script 

--- a/.github/workflows/runtime-test.yml
+++ b/.github/workflows/runtime-test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Pulling the repository..
         uses: actions/checkout@v2
       - name: Performing the test..
-        shell: bash
+        shell: powershell
         run: |
-          cd "$GITHUB_WORKSPACE"
+          cd $env:GITHUB_WORKSPACE
           make runtime-emacs-script 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,86 @@
+# Generated using: grep -oP "^[a-zA-Z-]+\:.*" Makefile | sed s/:.*// | grep -v PHONY | tr '\n' ' '
+PHONY: all list build
+
+# Metadata
+NAME ?= RXT0128
+VERSION = 0.0.0
+
+# Command overrides
+READ ?= read
+CHMOD ?= chmod
+PRINTF ?= printf
+EMACS ?= emacs
+GREP ?= grep
+SED ?= sed
+CAT ?= cat
+TRUE ?= true
+MKDIR ?= mkdir
+EXIT ?= exit
+GIT ?= git
+ED ?= ed
+CP ?= cp
+RM ?= rm
+SH ?= sh
+ENV ?= env
+MAKE ?= make
+
+# Directory overrides
+BUILD ?= "$(PWD)/build"
+DISTRO_DIR ?= "$(PWD)/src/RXT0128/
+
+#@ Default target invoked on 'make' (outputs syntax error on this project)
+all:
+	@ $(error Target 'all' is not allowed, use 'make list' to list available targets or read the 'Makefile' file)
+	@ "$(EXIT)" 2
+
+#@ List all targets
+list:
+	@ printf 'FIXME: %s\n' "Puts ': something' in the output, implement in a way that is comforming posix"
+	@ "$(TRUE)" \
+		&& "$(GREP)" -A 1 "^#@.*" Makefile | "$(SED)" s/--//gm | "$(SED)" "s/#@/#/gm" | while IFS= "$(READ)" -r line; do \
+			case "$$line" in \
+				"#"*|"") "$(PRINTF)" '%s\n' "$$line" ;; \
+				*) "$(PRINTF)" '%s\n' "make $$line"; \
+			esac; \
+		done
+
+#@ Remove temporary pathnames
+clean:
+	@ : "FIXME: Outputs: /bin/sh: 1: rm -f: not found when '$(RM)' is used"
+	@ [ ! -d "$(BUILD)" ] || rm -rf "$(BUILD)"
+
+
+#@ Build the distribution
+build: clean build-init-prepend build-codeblocks build-init-append
+
+#@ Build: Build the prepended part of init.el
+build-init-prepend:
+	@ [ -d "$(BUILD)" ] || "$(MKDIR)" "$(BUILD)"
+	@ [ -d "$(BUILD)/$(NAME)" ] || "$(MKDIR)" "$(BUILD)/$(NAME)"
+	@ [ -f "$(BUILD)/$(NAME)/init.el" ] || "$(CAT)" "$(DISTRO_DIR)/00-init-prepend.el" | grep -v ";;;-" | "$(SED)" "s/APPEND_DISTRO_NAME/$(NAME)/" > "$(BUILD)/$(NAME)/init.el"
+
+#@ Build: Build the appended part of init.el
+build-init-append:
+	@ [ -d "$(BUILD)" ] || "$(MKDIR)" "$(BUILD)"
+	@ [ -d "$(BUILD)/$(NAME)" ] || "$(MKDIR)" "$(BUILD)/$(NAME)"
+	@ : "FIXME: Sanitize this step"
+	@ "$(CAT)" "$(DISTRO_DIR)/01-init-append.el" | grep -v ";;;-" >> "$(BUILD)/$(NAME)/init.el"
+
+#@ Build: Codeblocks
+build-codeblocks: build-codeblocks-find-emacs-dirs
+
+#@ Build: Codeblock find-emacs-dirs
+build-codeblocks-find-emacs-dirs:
+	@ [ -d "$(BUILD)" ] || "$(MAKE)" build-init-prepend
+	@ [ -d "$(BUILD)/$(NAME)" ] || "$(MKDIR)" "$(BUILD)/$(NAME)"
+	@ "$(GREP)" -q "# find-emacs-dirs.el" "$(BUILD)/$(NAME)/init.el" || "$(CAT)" "$(DISTRO_DIR)/codeblocks/00-find-emacs-dirs.el" >> "$(BUILD)/$(NAME)/init.el"
+
+## RUNTIME ##
+
+#@ Runtime: Open emacs with distro release
+runtime-emacs-gui: build
+	@ "$(ENV)" EMACS_DIR="$(BUILD)/$(NAME)/" "$(EMACS)" -q --load "$(BUILD)/$(NAME)/init.el"
+
+#@ Runtime: Run only the elisp script through emacs and output in terminal
+runtime-emacs-script: build
+	@ "$(ENV)" EMACS_DIR="$(BUILD)/$(NAME)/" "$(EMACS)" --script "$(BUILD)/$(NAME)/init.el"

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,1 @@
+Source code of projects relevat to RXT0128

--- a/src/RXT0128/00-init-prepend.el
+++ b/src/RXT0128/00-init-prepend.el
@@ -1,0 +1,8 @@
+;;;- Content of this file is prepended to the created init.el file
+;;; init.el -- APPEND_DISTRO_NAME initization file
+;; Based on RXT0128 project <https://github.com/RXT0128> origically created by Jacob Hrbek identified using an electronic mail <kreyren@rixotstudio.cz> with GPG identifier 0x765AED304211C28410D5C478FCBA0482B0AB9F10 under all rights reserved in 17.07.2020 13:22:47
+
+;; Define the name of this distribution
+(defvar emacs-distro-name "APPEND_DISTRO_NAME" "Non-standard variable storing the name of used emacs distribution, this must be a string")
+
+(message (concat "Welcome to " emacs-distro-name "!"))

--- a/src/RXT0128/01-init-append.el
+++ b/src/RXT0128/01-init-append.el
@@ -1,0 +1,3 @@
+;;;- Content of this file is appended to the created init.el file
+
+(message (concat "Emacs distribution " emacs-distro-name " finished it's initization"))

--- a/src/RXT0128/codeblocks/README.md
+++ b/src/RXT0128/codeblocks/README.md
@@ -1,0 +1,1 @@
+Directory for various codeblocks that can't be sourced using `(loqe ...)` and so these are appended using a custom logic

--- a/src/RXT0128/codeblocks/README.md
+++ b/src/RXT0128/codeblocks/README.md
@@ -1,1 +1,1 @@
-Directory for various codeblocks that can't be sourced using `(loqe ...)` and so these are appended using a custom logic
+Directory for various codeblocks that can't be sourced using `(load ...)` and so these are appended using a custom logic

--- a/src/RXT0128/codeblocks/find-emacs-dirs.el
+++ b/src/RXT0128/codeblocks/find-emacs-dirs.el
@@ -16,18 +16,21 @@
 ;;;! ---
 ;;;!
 ;;;! WARNING: Use only standard functions as this is used at the header of the file during initialization to find the directory
+
+
 (cond
  ((> (length (getenv "EMACS_DIR")) 0)
   (setq user-emacs-directory (getenv "EMACS_DIR")))
  ;; If EMACS_DIR variable is unset or blank
- ((= (length (getenv "EMACS_DIR")) 0)
+ ((getenv "EMACS_DIR"))
   (cl-case system-type
     ((gnu gnu/linux)
      (cond
       ((> (length (getenv "XDG_CONFIG_HOME")) 0)
        ;; FIXME-QA: Implement check for expected directory
        (setq user-emacs-directory (concat (getenv "XDG_CONFIG_HOME") "/" emacs-distro-name)))
-      ((= (length (getenv "XDG_CONFIG_HOME")) 0)
+      ;; NOTICE(Krey): As of 05/09/2020-EU emacs needs full path stored in user-emacs-directory thus checking for slash on linux
+      ((string-match-p "^/" (or (getenv "XDG_CONFIG_HOME") ""))
        ;; FIXME-QA: Implement check for expected directory
        (setq user-emacs-directory (concat (getenv "HOME") "/" emacs-distro-name)))
       (t

--- a/src/RXT0128/codeblocks/find-emacs-dirs.el
+++ b/src/RXT0128/codeblocks/find-emacs-dirs.el
@@ -17,36 +17,30 @@
 ;;;!
 ;;;! WARNING: Use only standard functions as this is used at the header of the file during initialization to find the directory
 (cond
-	((> (length (getenv "EMACS_DIR")) 0)
-		(setq user-emacs-directory (getenv "EMACS_DIR"))
-	)
-	;; If EMACS_DIR variable is unset or blank
-	((= (length (getenv "EMACS_DIR")) 0)
-		(cl-case system-type
-			((gnu gnu/linux)
-				(cond
-					((> (length (getenv "XDG_CONFIG_HOME")) 0)
-						;; FIXME-QA: Implement check for expected directory
-						(setq user-emacs-directory (concat (getenv "XDG_CONFIG_HOME") "/" emacs-distro-name)) )
-					((= (length (getenv "XDG_CONFIG_HOME")) 0)
-						;; FIXME-QA: Implement check for expected directory
-						(setq user-emacs-directory (concat (getenv "HOME") "/" emacs-distro-name)) )
-					(t
-						(message "Unexpected happend while trying to find custom emacs distribution directory which is most likely a bug, you might want to use environment variable 'EMACS_DIR'")
-						(kill-emacs 250) )
-				)
-			)
-			((windows-nt ms-dos)
-				(princ "FIXME: Platform '%1$s' is not implemented in find-emacs-dirs.el codeblock")
-				(kill-emacs 28)	)
-			((gnu/kfreebsd darwin cygwin aix berkeley-unix hpux irix usg-unix-v)
-				(princ "FIXME: Platform '%1$s' is unimplemented aldo theoretically supported, exitting for safety as it was not tested" system-type)
-				(kill-emacs 28)	)
-			(t
-				(princ "Unexpected happend while processing system-type variable storing '%1$s', guessing not implemented?" system-type) )
-		)
-	)
-	(t
-		(message "Unexpected happend while looking for emacs directories in codeblock 'find-emacs-dirs.el'")
-		(kill-emacs 255) )
-)
+ ((> (length (getenv "EMACS_DIR")) 0)
+  (setq user-emacs-directory (getenv "EMACS_DIR")))
+ ;; If EMACS_DIR variable is unset or blank
+ ((= (length (getenv "EMACS_DIR")) 0)
+  (cl-case system-type
+    ((gnu gnu/linux)
+     (cond
+      ((> (length (getenv "XDG_CONFIG_HOME")) 0)
+       ;; FIXME-QA: Implement check for expected directory
+       (setq user-emacs-directory (concat (getenv "XDG_CONFIG_HOME") "/" emacs-distro-name)))
+      ((= (length (getenv "XDG_CONFIG_HOME")) 0)
+       ;; FIXME-QA: Implement check for expected directory
+       (setq user-emacs-directory (concat (getenv "HOME") "/" emacs-distro-name)))
+      (t
+       (message "Unexpected happend while trying to find custom emacs distribution directory which is most likely a bug, you might want to use environment variable 'EMACS_DIR'")
+       (kill-emacs 250))))
+    ((windows-nt ms-dos)
+     (princ "FIXME: Platform '%1$s' is not implemented in find-emacs-dirs.el codeblock")
+     (kill-emacs 28))
+    ((gnu/kfreebsd darwin cygwin aix berkeley-unix hpux irix usg-unix-v)
+     (princ "FIXME: Platform '%1$s' is unimplemented aldo theoretically supported, exitting for safety as it was not tested" system-type)
+     (kill-emacs 28))
+    (t
+     (princ "Unexpected happend while processing system-type variable storing '%1$s', guessing not implemented?" system-type))))
+ (t
+  (message "Unexpected happend while looking for emacs directories in codeblock 'find-emacs-dirs.el'")
+  (kill-emacs 255)))

--- a/src/RXT0128/codeblocks/find-emacs-dirs.el
+++ b/src/RXT0128/codeblocks/find-emacs-dirs.el
@@ -1,0 +1,52 @@
+;; Created by Jacob Hrbek identified using an electronic mail kreyren@rixotstudio.cz with GPG 0x765AED304211C28410D5C478FCBA0482B0AB9F10 under all rights reserved in 17.07.2020 13:22:47
+
+;;;! # find-emacs-dirs.el
+;;;! Find emacs directories allowing for an emacs distro that is independent from file hierarchy
+;;;!
+;;;! ## Expected directories
+;;;! On GNU/Linux we are expecting path '$XDG_CONFIG_HOME/<distro-name>' if XDG_CONFIG_HOME is not defined we will try to use '$HOME/.local/<distro-name>'
+;;;!
+;;;! On Windows FIXME-DOCS
+;;;!
+;;;! ## Variable EMACS_DISTRIBUTION_DATA
+;;;! Because 'emacs --eval ...' is evaluated after init.el we are using variable 'EMACS_DISTRIBUTION_DATA' that is evaluated during the init.el initialization to set value for 'user-emacs-directory' to make the distribution independent on the filesystem hierarchy
+;;;!
+;;;! If the variable is not defined, then the distribution is going to use hardcodded logic to find it
+;;;!
+;;;! ---
+;;;!
+;;;! WARNING: Use only standard functions as this is used at the header of the file during initialization to find the directory
+(cond
+	((> (length (getenv "EMACS_DIR")) 0)
+		(setq user-emacs-directory (getenv "EMACS_DIR"))
+	)
+	;; If EMACS_DIR variable is unset or blank
+	((= (length (getenv "EMACS_DIR")) 0)
+		(cl-case system-type
+			((gnu gnu/linux)
+				(cond
+					((> (length (getenv "XDG_CONFIG_HOME")) 0)
+						;; FIXME-QA: Implement check for expected directory
+						(setq user-emacs-directory (concat (getenv "XDG_CONFIG_HOME") "/" emacs-distro-name)) )
+					((= (length (getenv "XDG_CONFIG_HOME")) 0)
+						;; FIXME-QA: Implement check for expected directory
+						(setq user-emacs-directory (concat (getenv "HOME") "/" emacs-distro-name)) )
+					(t
+						(message "Unexpected happend while trying to find custom emacs distribution directory which is most likely a bug, you might want to use environment variable 'EMACS_DIR'")
+						(kill-emacs 250) )
+				)
+			)
+			((windows-nt ms-dos)
+				(princ "FIXME: Platform '%1$s' is not implemented in find-emacs-dirs.el codeblock")
+				(kill-emacs 28)	)
+			((gnu/kfreebsd darwin cygwin aix berkeley-unix hpux irix usg-unix-v)
+				(princ "FIXME: Platform '%1$s' is unimplemented aldo theoretically supported, exitting for safety as it was not tested" system-type)
+				(kill-emacs 28)	)
+			(t
+				(princ "Unexpected happend while processing system-type variable storing '%1$s', guessing not implemented?" system-type) )
+		)
+	)
+	(t
+		(message "Unexpected happend while looking for emacs directories in codeblock 'find-emacs-dirs.el'")
+		(kill-emacs 255) )
+)


### PR DESCRIPTION
By default emacs is using a hardcodded logic to use variable 'user-emacs-directory' to use it's user-specific features that prevents development of this project and makes emacs depending on the filehierarchy used.

This is implementing a codeblock with logic to locate the user directory using standard FHS 3.0 <https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html> while allowing using variable 'EMACS_DIR' to specify custom path.

Fixes: https://github.com/RXT0128/RXT0128/issues/1

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>